### PR TITLE
easier to read style for example LT curl call

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -57,7 +57,7 @@ Use the following example to translate "Hello, world!" from English to Spanish. 
 curl -u username:password \
 -X POST \
 -H "Accept: application/json" \
--d '{"text":"Hello, world","source":"en", "target":"es"}' \
+-d '{"text":"Hello, world", "source":"en", "target":"es"}' \
 https://gateway.watsonplatform.net/language-translator/api/v2/translate
 ```
 {:codeblock}

--- a/getting-started.md
+++ b/getting-started.md
@@ -54,7 +54,11 @@ If you use {{site.data.keyword.Bluemix_dedicated_notm}}, create your service ins
 Use the following example to translate "Hello, world!" from English to Spanish. Replace `{username}` and `{password}` with the service credentials you copied in the previous step.
 
 ```bash
-curl -X POST --user {username}:{password} --header "Content-Type: application/json" --header "Accept: application/json" --data "{\"text\":\"Hello, world\",\"source\":\"en\",\"target\":\"es\"}" https://gateway.watsonplatform.net/language-translator/api/v2/translate
+curl -u username:password \
+-X POST \
+-H "Accept: application/json" \
+-d '{"text":"Hello, world","source":"en", "target":"es"}' \
+https://gateway.watsonplatform.net/language-translator/api/v2/translate
 ```
 {:codeblock}
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -54,11 +54,7 @@ If you use {{site.data.keyword.Bluemix_dedicated_notm}}, create your service ins
 Use the following example to translate "Hello, world!" from English to Spanish. Replace `{username}` and `{password}` with the service credentials you copied in the previous step.
 
 ```bash
-curl -u username:password \
--X POST \
--H "Accept: application/json" \
--d '{"text":"Hello, world", "source":"en", "target":"es"}' \
-https://gateway.watsonplatform.net/language-translator/api/v2/translate
+curl -X POST --user {username}:{password} --header "Accept: application/json" --data "{\"text\":\"Hello, world\",\"source\":\"en\",\"target\":\"es\"}" https://gateway.watsonplatform.net/language-translator/api/v2/translate
 ```
 {:codeblock}
 


### PR DESCRIPTION
I am proposing a few minor changes to the sample curl call that make it more in-line with the [tech preview](https://console.bluemix.net/docs/services/language-translator/release-notes.html#12-january-2018) sample.

* The argument `--header "Content-Type: application/json"` is not necessary
* Consistent use of `-u username:password` (a single letter arg) instead of `--user {username}:{password}` (a double dash arg)
* Using a single quote around the data payload as opposed to a double quote and then escaping 12 other double quotes
* Using slashes to break things up so it's still copy & paste friendly but now reads better in a browser since the user doesn't have to scroll horizontally 