### PR TITLE
make 'using a custom language model' not broken

### DIFF
--- a/customizing.md
+++ b/customizing.md
@@ -187,7 +187,7 @@ After you train a custom translation model, specify the model\_id of that transl
 The following example invokes the English to French model that was customized in the [Training a custom translation model](#training) section.
 
 ```curl
-curl -u "{username}":"{password}" --header "Content-Type: application/json" -X POST --data '{"model_id": "3e7dfdbe-f757-4150-afee-458e71eb93fb","text": "Hello, my name is Watson, and I work for International Business Machines. How can I help you today?"}' https://gateway.watsonplatform.net/language-translator/api/v2/translate 
+curl -u "{username}":"{password}" --header "Content-Type: application/json" -X POST --data "{\"model_id\": \"3e7dfdbe-f757-4150-afee-458e71eb93fb\",\"text\": \"Hello, my name is Watson, and I work for International Business Machines. How can I help you today?\"}" https://gateway.watsonplatform.net/language-translator/api/v2/translate 
 ```
 {: codeblock}
 

--- a/customizing.md
+++ b/customizing.md
@@ -187,7 +187,7 @@ After you train a custom translation model, specify the model\_id of that transl
 The following example invokes the English to French model that was customized in the [Training a custom translation model](#training) section.
 
 ```curl
-curl -u "{username}":"{password}" --header "Content-Type: application/json" -X POST --data {"model_id": "3e7dfdbe-f757-4150-afee-458e71eb93fb","text": ["Hello, my name is Watson, and I work for International Business Machines. How can I help you today?"]}
+curl -u "{username}":"{password}" --header "Content-Type: application/json" -X POST --data '{"model_id": "3e7dfdbe-f757-4150-afee-458e71eb93fb","text": "Hello, my name is Watson, and I work for International Business Machines. How can I help you today?"}' https://gateway.watsonplatform.net/language-translator/api/v2/translate 
 ```
 {: codeblock}
 


### PR DESCRIPTION
There are several errors in the same `curl` call in the "Using a custom translation model" section:

* There is no URL specified, so added `https://gateway.watsonplatform.net/language-translator/api/v2/translate`
* According to the [API](https://www.ibm.com/watson/developercloud/language-translator/api/v2/?curl#translate), `text` is not an array but a string, so remove the square brackets around its value. I tested the same command with and without the square brackets, and it seems to work, but I think we should stick to whatever is in the API
* There are no single quotes around the data payload, which makes the shell interpret the curly brace, resulting in:

```
smartinelli-mac ~ $ curl -u foo:bar --header "Content-Typ: application/json" -X POST --data {"model_id": "a64e976d-be3e-4d16-a605-92a7afc14460","text": ["Hello, my name is Watson, and I work for International Business Machines. How can I help you today?"]}
curl: (6) Could not resolve host: a64e976d-be3e-4d16-a605-92a7afc14460,text
curl: (3) [globbing] bad range in column 2
```